### PR TITLE
DVO-6265 -> master | gull should default to 'localhost' when no server is specified

### DIFF
--- a/source/lib/common/common.go
+++ b/source/lib/common/common.go
@@ -1,3 +1,5 @@
 package common
 
 var DefaultGullDirectory = "_gull/"
+
+var DefaultEtcdServerUrl = "http://localhost:2379/v2/keys"

--- a/source/lib/gull/migrations.go
+++ b/source/lib/gull/migrations.go
@@ -9,7 +9,6 @@ import (
 type Migrations struct {
 	Entries []*Migration
 	Lookup  map[string]*Migration
-	logger  ILogger
 }
 
 func NewMigrations() *Migrations {

--- a/source/lib/ui/down_command.go
+++ b/source/lib/ui/down_command.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/c2fo/gull/source/lib/common"
 	"github.com/c2fo/gull/source/lib/gull"
 	"github.com/codegangsta/cli"
 )
@@ -34,6 +35,7 @@ func (dc *DownCommand) GetFlags() []cli.Flag {
 			Name:   "etcdhost, s",
 			Usage:  "url to the system running etcd in the format 'http://localhost:2379/v2/keys'",
 			EnvVar: "GULL_ETCD_HOST",
+			Value:  common.DefaultEtcdServerUrl,
 		},
 		cli.BoolFlag{
 			Name:   "verbose, v",
@@ -79,8 +81,8 @@ func (dc *DownCommand) ParseOptions(context *cli.Context) {
 	}
 
 	dc.EtcdHostUrl = context.String("etcdhost")
-	if dc.EtcdHostUrl == "" {
-		fmt.Println("No etcdhost was provided, but it is required")
+	if dc.EtcdHostUrl == common.DefaultEtcdServerUrl {
+		fmt.Printf("No etcdhost was provided, using [%v]\n", common.DefaultEtcdServerUrl)
 		os.Exit(1)
 	}
 }

--- a/source/lib/ui/launch.go
+++ b/source/lib/ui/launch.go
@@ -17,7 +17,7 @@ type GullCommand interface {
 func Launch() {
 	app := cli.NewApp()
 	app.Name = "gull"
-	app.Version = "0.9.0"
+	app.Version = "0.9.1"
 	app.Usage = "etcd configuration migration management system"
 	app.Commands = []cli.Command{
 		new(ConvertCommand).GetCliCommand(),
@@ -29,7 +29,7 @@ func Launch() {
 	err := app.Run(os.Args)
 	if err != nil {
 		if strings.Contains(err.Error(), "flag provided but not defined") {
-			fmt.Printf(err.Error())
+			fmt.Println(err.Error())
 		} else {
 			panic(err)
 		}

--- a/source/lib/ui/status_command.go
+++ b/source/lib/ui/status_command.go
@@ -1,8 +1,10 @@
 package ui
 
 import (
+	"fmt"
 	"os"
 
+	"github.com/c2fo/gull/source/lib/common"
 	"github.com/c2fo/gull/source/lib/gull"
 	"github.com/codegangsta/cli"
 )
@@ -31,6 +33,7 @@ func (sc *StatusCommand) GetFlags() []cli.Flag {
 			Name:   "etcdhost, s",
 			Usage:  "url to the system running etcd in the format 'http://localhost:2379/v2/keys'",
 			EnvVar: "GULL_ETCD_HOST",
+			Value:  common.DefaultEtcdServerUrl,
 		},
 	}
 }
@@ -62,9 +65,8 @@ func (sc *StatusCommand) ParseOptions(context *cli.Context) {
 	}
 
 	sc.EtcdHostUrl = context.String("etcdhost")
-	if sc.EtcdHostUrl == "" {
-		sc.Logger.Info("No etcdhost was not provided, but it is required")
-		os.Exit(1)
+	if sc.EtcdHostUrl == common.DefaultEtcdServerUrl {
+		fmt.Printf("No etcdhost was provided, using [%v]\n", common.DefaultEtcdServerUrl)
 	}
 }
 

--- a/source/lib/ui/up_command.go
+++ b/source/lib/ui/up_command.go
@@ -36,6 +36,7 @@ func (uc *UpCommand) GetFlags() []cli.Flag {
 			Name:   "etcdhost, s",
 			Usage:  "url to the system running etcd in the format 'http://localhost:2379/v2/keys'",
 			EnvVar: "GULL_ETCD_HOST",
+			Value:  common.DefaultEtcdServerUrl,
 		},
 		cli.StringFlag{
 			Name:   "source, i",


### PR DESCRIPTION
[JIRA Link](https://honeycomb.jira.com/browse/DVO-6265)
##### Issuer

@tim-kretschmer-c2fo - Tim Kretschmer
##### Code Review + Discussion Complete

If any user has commented on this PR, but has not checked his or her box below, then the PR cannot be merged.

Team Lead
- [ ] Team Lead Reviewed

Team
- [ ] @thomascarrollc2fo - Thomas Carroll
- [ ] @brockwood - Bryan Rockwood
- [ ] @achura - Adam Chura
